### PR TITLE
XMLDesc requires a flags parameter

### DIFF
--- a/virt-hosts
+++ b/virt-hosts
@@ -50,7 +50,7 @@ def main():
 
         for domId in con.listDomainsID():
             dom = con.lookupByID(domId)
-            desc = etree.fromstring(dom.XMLDesc())
+            desc = etree.fromstring(dom.XMLDesc(0))
 
             primary=True
             for iface in desc.xpath('/domain/devices/interface[@type="network"]'):


### PR DESCRIPTION
XMLDesc uses the VIR_DOMAIN_XML_\* flags, but in this case we don't want to use any of the flags, so we pass in 0.

Without using the flags parameter, the following traceback is thrown:

```
Traceback (most recent call last):
  File "/tmp/virt-hosts", line 82, in <module>
    main()
  File "/tmp/virt-hosts", line 53, in main
    desc = etree.fromstring(dom.XMLDesc())
TypeError: XMLDesc() takes exactly 2 arguments (1 given)
```
