### PR TITLE
virt-addr: use virsh net-dhcp-leases

### DIFF
--- a/create-config-drive
+++ b/create-config-drive
@@ -48,6 +48,18 @@ done
 config_image=$1
 shift
 
+if [ -z "$config_image" ]; then
+	echo "The imagename argument must be specified!" >&2
+	usage >&2
+	exit 3
+fi
+
+if [ $# -ne 0 ]; then
+	echo "This command requires exactly one positional argument!" >&2
+	usage >&2
+	exit 4
+fi
+
 if [ "$ssh_key" ] && [ -f "$ssh_key" ]; then
 	echo "adding pubkey from $ssh_key"
 	ssh_key_data=$(cat "$ssh_key")
@@ -83,9 +95,9 @@ if [ "$ssh_key_data" ]; then
 fi
 
 echo "generating configuration image at $config_image"
-if ! mkisofs -o $config_image -V cidata -r -J --quiet $config_dir; then
+if ! mkisofs -o "$config_image" -V cidata -r -J --quiet $config_dir; then
 	echo "ERROR: failed to create $config_image" >&2
 	exit 1
 fi
-chmod a+r $config_image
+chmod a+r "$config_image"
 

--- a/virt-addr
+++ b/virt-addr
@@ -15,7 +15,6 @@ while :; do
 			LIBVIRT_NETWORK=$2
 			shift 2
 			;;
-
 		-i|--index)
 			INTERFACE_INDEX=$2
 			shift 2
@@ -39,13 +38,12 @@ while :; do
 done
 
 : ${LIBVIRT_NETWORK:=default}
-: ${LIBVIRT_LEASE_FILE:=/var/lib/libvirt/dnsmasq/${LIBVIRT_NETWORK}.leases}
 : ${INTERFACE_INDEX:=1}
 
 dom_name=$1
 shift
 
-macaddr=$(virsh dumpxml $dom_name | 
+macaddr=$(virsh dumpxml $dom_name |
 	xmllint --xpath "string((//interface/mac/@address)[${INTERFACE_INDEX}])" -)
 
 if [ "$ONLY_MACADDR" = 1 ]; then
@@ -53,5 +51,11 @@ if [ "$ONLY_MACADDR" = 1 ]; then
 	exit
 fi
 
-awk -vmacaddress=$macaddr '$2 == macaddress {print $3}' $LIBVIRT_LEASE_FILE
-
+if virsh help | grep -q domifaddr; then
+	virsh -q net-dhcp-leases ${LIBVIRT_NETWORK} | \
+		awk -vmacaddress=$macaddr '$3 == macaddress {print substr($5, 0, index($5, "/")-1)}'
+else
+	: ${LIBVIRT_LEASE_FILE:=/var/lib/libvirt/dnsmasq/${LIBVIRT_NETWORK}.leases}
+	awk -vmacaddress=$macaddr '$2 == macaddress {print $3}' \
+		${LIBVIRT_LEASE_FILE}
+fi


### PR DESCRIPTION
It seems that in recent libvirt (e.g. Fedora 23 or RHEL 7.2) leases
aren't written to a .leases file, but there is now a net-dhcp-leases
virsh command.

Make virt-addr use this net-dhcp-leases command in a rather goofy
way.

Note that virt-hosts needs a similar fix.

Note also that virsh domifaddr looks like it might be a better choice,
but I've run into cases where domifaddr returns nothing but
net-dhcp-leases shows the VM. Haven't investigated further.
